### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A Model Context Protocol server to connect to the MIRO Whiteboard Application.
 - Pass your OAuth key as an Environment Variable, or using the "--token" argument.
 - Taking a photo of stickies and asking Claude to create MIRO equivalent works _really_ well.
 
+<a href="https://glama.ai/mcp/servers/gr5t7vthv3"><img width="380" height="200" src="https://glama.ai/mcp/servers/gr5t7vthv3/badge" alt="mcp-miro MCP server" /></a>
+
 ## Installation
 
 ### Using mcp-get


### PR DESCRIPTION
This PR adds a badge for the mcp-miro server listing in Glama MCP server directory.

https://glama.ai/mcp/servers/gr5t7vthv3

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.